### PR TITLE
Changes to make it compile on Arch linux

### DIFF
--- a/src/mngr650.pro
+++ b/src/mngr650.pro
@@ -63,5 +63,6 @@ unix {
         message(Building for Linux)
         SOURCES     += umount_lin.cpp
         DEFINES     += LINUX
+        LIBS        += -lz
     }
 }

--- a/src/umount_lin.cpp
+++ b/src/umount_lin.cpp
@@ -10,6 +10,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <unistd.h>
 
 #if defined(LINUX)
 #include <mntent.h>


### PR DESCRIPTION
1. Adds a missing `#include <unistd.h>`
2. Adds `-lz` to `LIBS` in order to link with libz.
